### PR TITLE
Implement basic document persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This repository contains a work-in-progress port of the Automerge Repo from Rust
 
 ## Next steps
 
-1. Flesh out the Go implementation so it matches the capabilities of the Rust repo. Start with document data structures and persistence, then port the networking layer (see `rust/src/*.rs`).
+1. Flesh out the Go implementation so it matches the capabilities of the Rust repo. Networking layer still needs porting (see `rust/src/*.rs`).
 2. Expand the Go example under `cmd/example` into a minimal CLI demonstrating document creation, loading and storage using `repo.FsStore`.
 3. Create unit tests for the Go code. Aim for similar coverage as the Rust tests in `rust/tests`.
 4. Update the root `README.md` as new functionality becomes available.
@@ -12,7 +12,7 @@ This repository contains a work-in-progress port of the Automerge Repo from Rust
 ## TODO
 
 - [ ] Implement Automerge document data type or integrate an existing library.
-- [ ] Persist repository data to disk using `FsStore`.
+- [x] Persist repository data to disk using `FsStore`.
 - [ ] Add tests for `repo.Repo` and `repo.FsStore`.
 - [ ] Prototype networking support based on the Rust implementation.
 - [ ] Port or rewrite example programs from `rust/examples` in Go.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ the same high level API for working with Automerge documents and
 network peers. Development is at an early stage and the API should be
 considered unstable.
 
+Basic document persistence is available using `repo.FsStore`. See
+`cmd/example` for a minimal demonstration.
+
 ## Building
 
 This project uses Go modules. To download dependencies and build run:

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -2,12 +2,24 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/example/automerge-repo-go/repo"
 )
 
 func main() {
-	r := repo.New()
+	store := &repo.FsStore{Dir: "data"}
+	r := repo.NewWithStore(store)
+
 	doc := r.NewDoc()
-	fmt.Println("new repo:", r.ID)
-	fmt.Println("new document:", doc.ID)
+	doc.Set("greeting", "hello")
+	if err := r.SaveDoc(doc.ID); err != nil {
+		panic(err)
+	}
+
+	loaded, err := r.LoadDoc(doc.ID)
+	if err != nil {
+		panic(err)
+	}
+	value, _ := loaded.Get("greeting")
+	fmt.Println("loaded:", value)
 }

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -1,6 +1,8 @@
 package repo
 
 import (
+	"fmt"
+
 	"github.com/google/uuid"
 )
 
@@ -13,13 +15,28 @@ type RepoID = uuid.UUID
 // Document represents a single Automerge document.
 type Document struct {
 	ID   DocumentID
-	Data []byte // placeholder for encoded document
+	Data map[string]interface{}
+}
+
+// Set assigns a value in the document.
+func (d *Document) Set(key string, value interface{}) {
+	if d.Data == nil {
+		d.Data = make(map[string]interface{})
+	}
+	d.Data[key] = value
+}
+
+// Get retrieves a value from the document.
+func (d *Document) Get(key string) (interface{}, bool) {
+	v, ok := d.Data[key]
+	return v, ok
 }
 
 // Repo holds a collection of documents.
 type Repo struct {
-	ID   RepoID
-	docs map[DocumentID]*Document
+	ID    RepoID
+	docs  map[DocumentID]*Document
+	store *FsStore
 }
 
 // New returns a new empty repository with a random identifier.
@@ -27,9 +44,16 @@ func New() *Repo {
 	return &Repo{ID: uuid.New(), docs: make(map[DocumentID]*Document)}
 }
 
+// NewWithStore creates a repository that will persist documents using the provided store.
+func NewWithStore(store *FsStore) *Repo {
+	r := New()
+	r.store = store
+	return r
+}
+
 // NewDoc creates a new document within the repository and returns it.
 func (r *Repo) NewDoc() *Document {
-	doc := &Document{ID: uuid.New()}
+	doc := &Document{ID: uuid.New(), Data: make(map[string]interface{})}
 	r.docs[doc.ID] = doc
 	return doc
 }
@@ -38,4 +62,29 @@ func (r *Repo) NewDoc() *Document {
 func (r *Repo) GetDoc(id DocumentID) (*Document, bool) {
 	d, ok := r.docs[id]
 	return d, ok
+}
+
+// SaveDoc writes a document to disk using the repo's store.
+func (r *Repo) SaveDoc(id DocumentID) error {
+	if r.store == nil {
+		return fmt.Errorf("no store configured")
+	}
+	doc, ok := r.docs[id]
+	if !ok {
+		return fmt.Errorf("document %s not found", id)
+	}
+	return r.store.Save(doc)
+}
+
+// LoadDoc loads a document from disk into the repo.
+func (r *Repo) LoadDoc(id DocumentID) (*Document, error) {
+	if r.store == nil {
+		return nil, fmt.Errorf("no store configured")
+	}
+	doc, err := r.store.Load(id)
+	if err != nil {
+		return nil, err
+	}
+	r.docs[id] = doc
+	return doc, nil
 }


### PR DESCRIPTION
## Summary
- add support for saving/loading documents via `FsStore`
- integrate `FsStore` with `Repo` and example
- note persistence capability in README
- update project guidance in `AGENTS.md`

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f5924b1488326a3b0e181213a0a47