### PR TITLE
Integrate automerge-go library

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This repository contains a work-in-progress port of the Automerge Repo from Rust
 
 ## TODO
 
-- [ ] Implement Automerge document data type or integrate an existing library.
+- [x] Implement Automerge document data type or integrate an existing library.
 - [x] Persist repository data to disk using `FsStore`.
 - [x] Add tests for `repo.Repo` and `repo.FsStore`.
 - [ ] Prototype networking support based on the Rust implementation.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ the same high level API for working with Automerge documents and
 network peers. Development is at an early stage and the API should be
 considered unstable.
 
-Basic document persistence is available using `repo.FsStore`. See
-`cmd/example` for a minimal demonstration.
+Basic document persistence is available using `repo.FsStore` and documents
+internally use the [automerge-go](https://github.com/automerge/automerge-go)
+library. See `cmd/example` for a minimal demonstration.
 
 ## Building
 

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -11,7 +11,9 @@ func main() {
 	r := repo.NewWithStore(store)
 
 	doc := r.NewDoc()
-	doc.Set("greeting", "hello")
+	if err := doc.Set("greeting", "hello"); err != nil {
+		panic(err)
+	}
 	if err := r.SaveDoc(doc.ID); err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/example/automerge-repo-go
 go 1.24.3
 
 require github.com/google/uuid v1.6.0
+
+require github.com/automerge/automerge-go v0.0.0-20241030180337-6fb4f2d08244 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/automerge/automerge-go v0.0.0-20241030180337-6fb4f2d08244 h1:zzw/8zTEZKROqQe9HzRyEin/ylr96Yy5th6Ej4Mxp20=
+github.com/automerge/automerge-go v0.0.0-20241030180337-6fb4f2d08244/go.mod h1:6UxoDE+thWsISXK93pxaOuOfkcAfCvDbg0eAnFmxL5E=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/repo/fsstore_test.go
+++ b/repo/fsstore_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	automerge "github.com/automerge/automerge-go"
 	"github.com/google/uuid"
 )
 
@@ -13,13 +14,16 @@ func TestFsStoreSaveLoadList(t *testing.T) {
 	store := &FsStore{Dir: dir}
 
 	// create document
-	doc := &Document{ID: uuid.New(), Data: map[string]interface{}{"foo": "bar"}}
+	doc := &Document{ID: uuid.New(), doc: automerge.New()}
+	if err := doc.Set("foo", "bar"); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
 	if err := store.Save(doc); err != nil {
 		t.Fatalf("Save failed: %v", err)
 	}
 
 	// file should exist
-	path := filepath.Join(dir, doc.ID.String()+".json")
+	path := filepath.Join(dir, doc.ID.String()+".automerge")
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("expected file %s to exist: %v", path, err)
 	}
@@ -29,8 +33,8 @@ func TestFsStoreSaveLoadList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load failed: %v", err)
 	}
-	if v, ok := loaded.Data["foo"]; !ok || v != "bar" {
-		t.Fatalf("unexpected loaded data: %v", loaded.Data)
+	if v, ok := loaded.Get("foo"); !ok || v != "bar" {
+		t.Fatalf("unexpected loaded data: %v", v)
 	}
 
 	// list ids

--- a/repo/repo_test.go
+++ b/repo/repo_test.go
@@ -10,7 +10,9 @@ func TestRepoSaveLoadDoc(t *testing.T) {
 	r := NewWithStore(store)
 
 	doc := r.NewDoc()
-	doc.Set("name", "Alice")
+	if err := doc.Set("name", "Alice"); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
 
 	if err := r.SaveDoc(doc.ID); err != nil {
 		t.Fatalf("SaveDoc failed: %v", err)


### PR DESCRIPTION
## Summary
- adopt automerge-go for document handling
- persist automerge binary format via FsStore
- update tests and example for new API
- note automerge dependency in README
- mark TODO item complete in AGENTS

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688093d394e483268ad7ff2f15f8789d