### PR TITLE
Add CLI example and update docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ This repository contains a work-in-progress port of the Automerge Repo from Rust
 ## Next steps
 
 1. Flesh out the Go implementation so it matches the capabilities of the Rust repo. Networking layer still needs porting (see `rust/src/*.rs`).
-2. Expand the Go example under `cmd/example` into a minimal CLI demonstrating document creation, loading and storage using `repo.FsStore`.
+2. Expand the Go example under `cmd/example` into a minimal CLI demonstrating document creation, loading and storage using `repo.FsStore`. **(done)**
 3. Create unit tests for the Go code. Aim for similar coverage as the Rust tests in `rust/tests`. **(done)**
 4. Update the root `README.md` as new functionality becomes available.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,21 @@ considered unstable.
 
 Basic document persistence is available using `repo.FsStore` and documents
 internally use the [automerge-go](https://github.com/automerge/automerge-go)
-library. See `cmd/example` for a minimal demonstration.
+library. The program under `cmd/example` provides a small CLI for creating and
+editing documents stored on disk.
+
+Run it with:
+
+```bash
+go run ./cmd/example <command>
+```
+
+Available commands are:
+
+* `new` - create a new document and print its ID
+* `list` - list stored document IDs
+* `set <id> <key> <value>` - set a key/value pair in a document
+* `get <id> <key>` - print a value from a document
 
 ## Building
 

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -2,26 +2,82 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/example/automerge-repo-go/repo"
+	"github.com/google/uuid"
 )
 
+func usage() {
+	fmt.Println(`Usage:
+  example new                       create a new document
+  example list                      list document IDs
+  example set <id> <key> <value>    set a value in a document
+  example get <id> <key>            get a value from a document`)
+}
+
 func main() {
+	if len(os.Args) < 2 {
+		usage()
+		return
+	}
+
 	store := &repo.FsStore{Dir: "data"}
 	r := repo.NewWithStore(store)
 
-	doc := r.NewDoc()
-	if err := doc.Set("greeting", "hello"); err != nil {
-		panic(err)
+	switch os.Args[1] {
+	case "new":
+		doc := r.NewDoc()
+		if err := r.SaveDoc(doc.ID); err != nil {
+			panic(err)
+		}
+		fmt.Println(doc.ID)
+	case "list":
+		ids, err := store.List()
+		if err != nil {
+			panic(err)
+		}
+		for _, id := range ids {
+			fmt.Println(id)
+		}
+	case "set":
+		if len(os.Args) != 5 {
+			usage()
+			return
+		}
+		id, err := uuid.Parse(os.Args[2])
+		if err != nil {
+			panic(err)
+		}
+		key, value := os.Args[3], os.Args[4]
+		doc, err := r.LoadDoc(id)
+		if err != nil {
+			panic(err)
+		}
+		if err := doc.Set(key, value); err != nil {
+			panic(err)
+		}
+		if err := r.SaveDoc(id); err != nil {
+			panic(err)
+		}
+	case "get":
+		if len(os.Args) != 4 {
+			usage()
+			return
+		}
+		id, err := uuid.Parse(os.Args[2])
+		if err != nil {
+			panic(err)
+		}
+		key := os.Args[3]
+		doc, err := r.LoadDoc(id)
+		if err != nil {
+			panic(err)
+		}
+		if v, ok := doc.Get(key); ok {
+			fmt.Println(v)
+		}
+	default:
+		usage()
 	}
-	if err := r.SaveDoc(doc.ID); err != nil {
-		panic(err)
-	}
-
-	loaded, err := r.LoadDoc(doc.ID)
-	if err != nil {
-		panic(err)
-	}
-	value, _ := loaded.Get("greeting")
-	fmt.Println("loaded:", value)
 }


### PR DESCRIPTION
## Summary
- expand `cmd/example` into a small CLI supporting creating, listing and editing documents
- document the CLI in README
- mark example CLI step complete in `AGENTS.md`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68809696371883269252197bd5520a50