### PR TITLE
Add prototype networking handshake

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This repository contains a work-in-progress port of the Automerge Repo from Rust
 
 ## Next steps
 
-1. Flesh out the Go implementation so it matches the capabilities of the Rust repo. Networking layer still needs porting (see `rust/src/*.rs`).
+1. Flesh out the Go implementation so it matches the capabilities of the Rust repo. Basic networking handshake prototyped, more work needed (see `rust/src/*.rs`).
 2. Expand the Go example under `cmd/example` into a minimal CLI demonstrating document creation, loading and storage using `repo.FsStore`. **(done)**
 3. Create unit tests for the Go code. Aim for similar coverage as the Rust tests in `rust/tests`. **(done)**
 4. Update the root `README.md` as new functionality becomes available.
@@ -14,7 +14,7 @@ This repository contains a work-in-progress port of the Automerge Repo from Rust
 - [x] Implement Automerge document data type or integrate an existing library.
 - [x] Persist repository data to disk using `FsStore`.
 - [x] Add tests for `repo.Repo` and `repo.FsStore`.
-- [ ] Prototype networking support based on the Rust implementation.
+- [x] Prototype networking support based on the Rust implementation.
 - [ ] Port or rewrite example programs from `rust/examples` in Go.
 
 ## Maintaining this file

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ been moved to the `rust/` directory for reference.
 The goal of this port is to provide a Go implementation that offers
 the same high level API for working with Automerge documents and
 network peers. Development is at an early stage and the API should be
-considered unstable.
+considered unstable. A prototype networking handshake is now
+available via `repo.Handshake`.
 
 Basic document persistence is available using `repo.FsStore` and documents
 internally use the [automerge-go](https://github.com/automerge/automerge-go)

--- a/repo/network.go
+++ b/repo/network.go
@@ -1,0 +1,84 @@
+package repo
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// ConnDirection indicates if we initiated a connection or accepted one.
+type ConnDirection int
+
+const (
+	Incoming ConnDirection = iota
+	Outgoing
+)
+
+type handshakeMessage struct {
+	Type     string `json:"type"`
+	SenderID RepoID `json:"senderId"`
+}
+
+// Handshake performs a simple join/peer handshake over the given connection.
+// It returns the remote repository ID after the handshake completes.
+func Handshake(rw io.ReadWriter, id RepoID, dir ConnDirection) (RepoID, error) {
+	enc := json.NewEncoder(rw)
+	dec := json.NewDecoder(bufio.NewReader(rw))
+	switch dir {
+	case Outgoing:
+		if err := enc.Encode(handshakeMessage{Type: "join", SenderID: id}); err != nil {
+			return RepoID{}, err
+		}
+		var resp handshakeMessage
+		if err := dec.Decode(&resp); err != nil {
+			return RepoID{}, err
+		}
+		if resp.Type != "peer" {
+			return RepoID{}, fmt.Errorf("unexpected message %q", resp.Type)
+		}
+		return resp.SenderID, nil
+	case Incoming:
+		var req handshakeMessage
+		if err := dec.Decode(&req); err != nil {
+			return RepoID{}, err
+		}
+		if req.Type != "join" {
+			return RepoID{}, fmt.Errorf("unexpected message %q", req.Type)
+		}
+		if err := enc.Encode(handshakeMessage{Type: "peer", SenderID: id}); err != nil {
+			return RepoID{}, err
+		}
+		return req.SenderID, nil
+	default:
+		return RepoID{}, fmt.Errorf("invalid direction")
+	}
+}
+
+// handshakePipe is a helper for tests that connects two sides of a net.Pipe and
+// runs Handshake concurrently.
+func handshakePipe(c1 io.ReadWriter, dir1 ConnDirection, id1 RepoID, c2 io.ReadWriter, dir2 ConnDirection, id2 RepoID) (RepoID, RepoID, error) {
+	var wg sync.WaitGroup
+	var r1 RepoID
+	var e1 error
+	var r2 RepoID
+	var e2 error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		r1, e1 = Handshake(c1, id1, dir1)
+	}()
+	go func() {
+		defer wg.Done()
+		r2, e2 = Handshake(c2, id2, dir2)
+	}()
+	wg.Wait()
+	if e1 != nil {
+		return RepoID{}, RepoID{}, e1
+	}
+	if e2 != nil {
+		return RepoID{}, RepoID{}, e2
+	}
+	return r1, r2, nil
+}

--- a/repo/network_test.go
+++ b/repo/network_test.go
@@ -1,0 +1,20 @@
+package repo
+
+import (
+	"net"
+	"testing"
+)
+
+func TestHandshake(t *testing.T) {
+	c1, c2 := net.Pipe()
+	repo1 := New()
+	repo2 := New()
+
+	r1, r2, err := handshakePipe(c1, Outgoing, repo1.ID, c2, Incoming, repo2.ID)
+	if err != nil {
+		t.Fatalf("handshake error: %v", err)
+	}
+	if r1 != repo2.ID || r2 != repo1.ID {
+		t.Fatalf("unexpected IDs: %v %v", r1, r2)
+	}
+}


### PR DESCRIPTION
## Summary
- implement simple join/peer handshake in new `repo.Handshake`
- add unit test for handshake
- update README to mention new handshake support
- mark networking prototype as done in AGENTS guide

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6880a9bb53a08326a3828023d3d5fd10