### PR TITLE
Add TCP connector

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,6 @@ several subsystems:
 ## Maintaining this file
 
 Whenever you make progress on the project, update the **Next steps** and **TODO** lists above. When you commit changes that complete an item, mark it as done with an `x` (e.g. `- [x]`). Add any new tasks or notes that future agents should be aware of. Keep this file concise and focused on actionable items.
+
+See [ROADMAP_PROGRESS.md](ROADMAP_PROGRESS.md) for a log of work completed on
+the production roadmap and notes on remaining tasks.

--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -1,0 +1,21 @@
+# Roadmap Progress
+
+This document captures work done towards **Part 2: Roadmap to Production**.
+It summarizes implemented functionality and notes remaining tasks to guide
+future development.
+
+## Implemented
+
+- Added a basic TCP connector in `repo/connector.go`.
+  - Provides `LPConn` for sending/receiving length‑prefixed JSON messages.
+  - Includes `Connect` helper which performs the join/peer handshake and
+    returns the remote repository ID along with a connection handle.
+  - Unit test `TestConnect` exercises the handshake over a `net.Pipe`.
+
+## Missing / Next Steps
+
+- WebSocket support and integration with the connector API.
+- Handling of `RepoMessage` types (sync and ephemeral messages).
+- Connection lifecycle management and background goroutines similar to the
+  Rust `RepoHandle` implementation.
+- Integration of connectors with the example CLI for real networking.

--- a/repo/connector.go
+++ b/repo/connector.go
@@ -1,0 +1,89 @@
+package repo
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+)
+
+// LPConn wraps a connection and exchanges length-prefixed JSON messages.
+type LPConn struct {
+	rw io.ReadWriteCloser
+	mu sync.Mutex
+}
+
+// NewLPConn returns a new length prefixed connection.
+func NewLPConn(rw io.ReadWriteCloser) *LPConn {
+	return &LPConn{rw: rw}
+}
+
+// Send encodes v as JSON and writes it with a 4 byte length prefix.
+func (c *LPConn) Send(v interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(data)))
+	if _, err := c.rw.Write(lenBuf[:]); err != nil {
+		return err
+	}
+	_, err = c.rw.Write(data)
+	return err
+}
+
+// Recv reads a length prefixed JSON message into v.
+func (c *LPConn) Recv(v interface{}) error {
+	var lenBuf [4]byte
+	if _, err := io.ReadFull(c.rw, lenBuf[:]); err != nil {
+		return err
+	}
+	n := binary.BigEndian.Uint32(lenBuf[:])
+	data := make([]byte, n)
+	if _, err := io.ReadFull(c.rw, data); err != nil {
+		return err
+	}
+	return json.Unmarshal(data, v)
+}
+
+// Close closes the underlying connection.
+func (c *LPConn) Close() error { return c.rw.Close() }
+
+// Connect performs a handshake over conn using length-prefixed messages and
+// returns the remote repo ID along with a LPConn for further communication.
+func Connect(conn net.Conn, id RepoID, dir ConnDirection) (*LPConn, RepoID, error) {
+	lp := NewLPConn(conn)
+	switch dir {
+	case Outgoing:
+		if err := lp.Send(handshakeMessage{Type: "join", SenderID: id}); err != nil {
+			return nil, RepoID{}, err
+		}
+		var resp handshakeMessage
+		if err := lp.Recv(&resp); err != nil {
+			return nil, RepoID{}, err
+		}
+		if resp.Type != "peer" {
+			return nil, RepoID{}, fmt.Errorf("unexpected message %q", resp.Type)
+		}
+		return lp, resp.SenderID, nil
+	case Incoming:
+		var req handshakeMessage
+		if err := lp.Recv(&req); err != nil {
+			return nil, RepoID{}, err
+		}
+		if req.Type != "join" {
+			return nil, RepoID{}, fmt.Errorf("unexpected message %q", req.Type)
+		}
+		if err := lp.Send(handshakeMessage{Type: "peer", SenderID: id}); err != nil {
+			return nil, RepoID{}, err
+		}
+		return lp, req.SenderID, nil
+	default:
+		return nil, RepoID{}, fmt.Errorf("invalid direction")
+	}
+}

--- a/repo/connector_test.go
+++ b/repo/connector_test.go
@@ -1,0 +1,39 @@
+package repo
+
+import (
+	"net"
+	"testing"
+)
+
+func TestConnect(t *testing.T) {
+	c1, c2 := net.Pipe()
+	repo1 := New()
+	repo2 := New()
+
+	var remote1 RepoID
+	var remote2 RepoID
+	var lp1 *LPConn
+	var lp2 *LPConn
+	errCh := make(chan error, 2)
+	go func() {
+		var err error
+		lp1, remote1, err = Connect(c1, repo1.ID, Outgoing)
+		errCh <- err
+	}()
+	go func() {
+		var err error
+		lp2, remote2, err = Connect(c2, repo2.ID, Incoming)
+		errCh <- err
+	}()
+	if err := <-errCh; err != nil {
+		t.Fatalf("connect error: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("connect error: %v", err)
+	}
+	if remote1 != repo2.ID || remote2 != repo1.ID {
+		t.Fatalf("unexpected repo IDs: %v %v", remote1, remote2)
+	}
+	lp1.Close()
+	lp2.Close()
+}


### PR DESCRIPTION
## Summary
- add `LPConn` and `Connect` to provide a length-prefixed TCP connector
- test the connector handshake
- track progress for Part 2 in `ROADMAP_PROGRESS.md`
- reference progress file from `AGENTS.md`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6881090094188326853d687173ba4d18