### PR TITLE
Add WebSocket connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ go run ./cmd/tcp-example -connect localhost:9999
 
 Each side prints the remote repository ID once the handshake completes.
 
+WebSocket connections are supported via `repo.DialWebSocket` and
+`repo.AcceptWebSocket`. They use the same join/peer handshake over a WebSocket
+upgrade so repositories can communicate through standard HTTP servers or
+browsers.
+
 ## Building
 
 This project uses Go modules. To download dependencies and build run:

--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -11,10 +11,12 @@ future development.
   - Includes `Connect` helper which performs the join/peer handshake and
     returns the remote repository ID along with a connection handle.
   - Unit test `TestConnect` exercises the handshake over a `net.Pipe`.
+- Added WebSocket connector helpers `DialWebSocket` and `AcceptWebSocket`.
+  - Uses Gorilla WebSocket to upgrade HTTP connections and send JSON messages.
+  - Unit test `TestWebSocketHandshake` verifies the WebSocket handshake.
 
 ## Missing / Next Steps
 
-- WebSocket support and integration with the connector API.
 - Handling of `RepoMessage` types (sync and ephemeral messages).
 - Connection lifecycle management and background goroutines similar to the
   Rust `RepoHandle` implementation.

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,8 @@ go 1.24.3
 
 require github.com/google/uuid v1.6.0
 
-require github.com/automerge/automerge-go v0.0.0-20241030180337-6fb4f2d08244 // indirect
+require (
+	github.com/automerge/automerge-go v0.0.0-20241030180337-6fb4f2d08244 // indirect
+	github.com/gorilla/websocket v1.5.1 // indirect
+	golang.org/x/net v0.17.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,7 @@ github.com/automerge/automerge-go v0.0.0-20241030180337-6fb4f2d08244 h1:zzw/8zTE
 github.com/automerge/automerge-go v0.0.0-20241030180337-6fb4f2d08244/go.mod h1:6UxoDE+thWsISXK93pxaOuOfkcAfCvDbg0eAnFmxL5E=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
+github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
+golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
+golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=

--- a/repo/websocket.go
+++ b/repo/websocket.go
@@ -1,0 +1,95 @@
+package repo
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/gorilla/websocket"
+)
+
+// WSConn wraps a websocket connection for sending JSON messages.
+type WSConn struct {
+	c  *websocket.Conn
+	mu sync.Mutex
+}
+
+// NewWSConn creates a new WSConn.
+func NewWSConn(c *websocket.Conn) *WSConn {
+	return &WSConn{c: c}
+}
+
+// Send encodes v as JSON and writes it over the websocket.
+func (c *WSConn) Send(v interface{}) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.c.WriteJSON(v)
+}
+
+// Recv reads a JSON message into v.
+func (c *WSConn) Recv(v interface{}) error {
+	return c.c.ReadJSON(v)
+}
+
+// Close closes the websocket.
+func (c *WSConn) Close() error { return c.c.Close() }
+
+// DialWebSocket dials the given websocket URL and performs the join/peer handshake.
+// It returns the remote repository ID and a connection handle for further
+// communication.
+func DialWebSocket(u string, id RepoID) (*WSConn, RepoID, error) {
+	// ensure scheme is ws/wss
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return nil, RepoID{}, err
+	}
+	if parsed.Scheme != "ws" && parsed.Scheme != "wss" {
+		return nil, RepoID{}, fmt.Errorf("invalid websocket url: %s", u)
+	}
+	conn, _, err := websocket.DefaultDialer.Dial(u, nil)
+	if err != nil {
+		return nil, RepoID{}, err
+	}
+	ws := NewWSConn(conn)
+	if err := ws.Send(handshakeMessage{Type: "join", SenderID: id}); err != nil {
+		ws.Close()
+		return nil, RepoID{}, err
+	}
+	var resp handshakeMessage
+	if err := ws.Recv(&resp); err != nil {
+		ws.Close()
+		return nil, RepoID{}, err
+	}
+	if resp.Type != "peer" {
+		ws.Close()
+		return nil, RepoID{}, fmt.Errorf("unexpected message %q", resp.Type)
+	}
+	return ws, resp.SenderID, nil
+}
+
+// AcceptWebSocket upgrades an HTTP request to a websocket and completes the
+// join/peer handshake. The returned connection can be used for JSON message
+// exchange.
+func AcceptWebSocket(w http.ResponseWriter, r *http.Request, id RepoID) (*WSConn, RepoID, error) {
+	upgrader := websocket.Upgrader{}
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return nil, RepoID{}, err
+	}
+	ws := NewWSConn(conn)
+	var req handshakeMessage
+	if err := ws.Recv(&req); err != nil {
+		ws.Close()
+		return nil, RepoID{}, err
+	}
+	if req.Type != "join" {
+		ws.Close()
+		return nil, RepoID{}, fmt.Errorf("unexpected message %q", req.Type)
+	}
+	if err := ws.Send(handshakeMessage{Type: "peer", SenderID: id}); err != nil {
+		ws.Close()
+		return nil, RepoID{}, err
+	}
+	return ws, req.SenderID, nil
+}

--- a/repo/websocket_test.go
+++ b/repo/websocket_test.go
@@ -1,0 +1,43 @@
+package repo
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestWebSocketHandshake(t *testing.T) {
+	serverRepo := New()
+	clientRepo := New()
+
+	var remoteFromServer RepoID
+	var wsErr error
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, remote, err := AcceptWebSocket(w, r, serverRepo.ID)
+		if err != nil {
+			wsErr = err
+			return
+		}
+		remoteFromServer = remote
+		conn.Close()
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+
+	conn, remoteFromClient, err := DialWebSocket(wsURL, clientRepo.ID)
+	if err != nil {
+		t.Fatalf("dial error: %v", err)
+	}
+	conn.Close()
+
+	if wsErr != nil {
+		t.Fatalf("accept error: %v", wsErr)
+	}
+
+	if remoteFromClient != serverRepo.ID || remoteFromServer != clientRepo.ID {
+		t.Fatalf("unexpected repo IDs: %v %v", remoteFromClient, remoteFromServer)
+	}
+}


### PR DESCRIPTION
## Summary
- add `DialWebSocket` and `AcceptWebSocket` helpers
- use gorilla/websocket for JSON message exchange
- create tests for WebSocket handshake
- document new connector in README and ROADMAP_PROGRESS

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68810b5e44448326a1390617cd445285