### PR TITLE
Implement RepoMessage encoding

### DIFF
--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -14,10 +14,12 @@ future development.
 - Added WebSocket connector helpers `DialWebSocket` and `AcceptWebSocket`.
   - Uses Gorilla WebSocket to upgrade HTTP connections and send JSON messages.
   - Unit test `TestWebSocketHandshake` verifies the WebSocket handshake.
+- Introduced `RepoMessage` type and JSON encoding helpers in `repo/message.go`.
+  - Supports `sync` and `ephemeral` message variants.
+  - Added unit test `TestRepoMessageEncodeDecode` for round‑trip validation.
 
 ## Missing / Next Steps
-
-- Handling of `RepoMessage` types (sync and ephemeral messages).
+- Integrate `RepoMessage` handling with connectors for full sync protocol.
 - Connection lifecycle management and background goroutines similar to the
   Rust `RepoHandle` implementation.
 - Integration of connectors with the example CLI for real networking.

--- a/repo/message.go
+++ b/repo/message.go
@@ -1,0 +1,58 @@
+package repo
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// RepoMessage represents a sync or ephemeral message exchanged between repositories.
+// Type should be either "sync" or "ephemeral".
+type RepoMessage struct {
+	Type       string // "sync" or "ephemeral"
+	FromRepoID RepoID
+	ToRepoID   RepoID
+	DocumentID DocumentID
+	Message    []byte
+}
+
+// repoMessageJSON mirrors the on-the-wire JSON structure.
+type repoMessageJSON struct {
+	Type       string     `json:"type"`
+	SenderID   RepoID     `json:"senderId"`
+	TargetID   RepoID     `json:"targetId"`
+	DocumentID DocumentID `json:"documentId"`
+	Message    []byte     `json:"message"`
+}
+
+// Encode converts the RepoMessage into JSON bytes for transmission.
+func (m RepoMessage) Encode() ([]byte, error) {
+	if m.Type != "sync" && m.Type != "ephemeral" {
+		return nil, fmt.Errorf("invalid RepoMessage type %q", m.Type)
+	}
+	wire := repoMessageJSON{
+		Type:       m.Type,
+		SenderID:   m.FromRepoID,
+		TargetID:   m.ToRepoID,
+		DocumentID: m.DocumentID,
+		Message:    m.Message,
+	}
+	return json.Marshal(wire)
+}
+
+// DecodeRepoMessage parses JSON data into a RepoMessage.
+func DecodeRepoMessage(data []byte) (RepoMessage, error) {
+	var wire repoMessageJSON
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return RepoMessage{}, err
+	}
+	if wire.Type != "sync" && wire.Type != "ephemeral" {
+		return RepoMessage{}, fmt.Errorf("invalid RepoMessage type %q", wire.Type)
+	}
+	return RepoMessage{
+		Type:       wire.Type,
+		FromRepoID: wire.SenderID,
+		ToRepoID:   wire.TargetID,
+		DocumentID: wire.DocumentID,
+		Message:    wire.Message,
+	}, nil
+}

--- a/repo/message_test.go
+++ b/repo/message_test.go
@@ -1,0 +1,29 @@
+package repo
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestRepoMessageEncodeDecode(t *testing.T) {
+	msg := RepoMessage{
+		Type:       "sync",
+		FromRepoID: New().ID, // just use random id
+		ToRepoID:   New().ID,
+		DocumentID: uuid.New(),
+		Message:    []byte("hello"),
+	}
+	data, err := msg.Encode()
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+	round, err := DecodeRepoMessage(data)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if round.Type != msg.Type || round.FromRepoID != msg.FromRepoID || round.ToRepoID != msg.ToRepoID || round.DocumentID != msg.DocumentID || !bytes.Equal(round.Message, msg.Message) {
+		t.Fatalf("round trip mismatch: %+v vs %+v", msg, round)
+	}
+}


### PR DESCRIPTION
## Summary
- implement RepoMessage struct with JSON encode/decode helpers
- test encode/decode round trips
- document progress in `ROADMAP_PROGRESS.md`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68810cb6cdec832688cb2831679aee0a