### PR TITLE
Add RepoMessage message exchange

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ This repository contains a work-in-progress port of the Automerge Repo from Rust
 - [x] Add tests for `repo.Repo` and `repo.FsStore`.
 - [x] Prototype networking support based on the Rust implementation.
 - [x] Port or rewrite example programs from `rust/examples` in Go.
+- [x] Integrate `RepoMessage` handling with connectors.
+- [ ] Implement `RepoHandle` style connection management and background sync.
 
 ## Part 2: Roadmap to Production
 

--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -17,9 +17,12 @@ future development.
 - Introduced `RepoMessage` type and JSON encoding helpers in `repo/message.go`.
   - Supports `sync` and `ephemeral` message variants.
   - Added unit test `TestRepoMessageEncodeDecode` for round‑trip validation.
+- Extended `LPConn` and `WSConn` with `SendMessage`/`RecvMessage` for
+  transmitting `RepoMessage` values.
+  - Added unit tests `TestLPConnSendRecvMessage` and `TestWSConnSendRecvMessage`
+    verifying JSON message exchange.
 
 ## Missing / Next Steps
-- Integrate `RepoMessage` handling with connectors for full sync protocol.
 - Connection lifecycle management and background goroutines similar to the
   Rust `RepoHandle` implementation.
 - Integration of connectors with the example CLI for real networking.

--- a/repo/websocket.go
+++ b/repo/websocket.go
@@ -32,6 +32,26 @@ func (c *WSConn) Recv(v interface{}) error {
 	return c.c.ReadJSON(v)
 }
 
+// SendMessage sends a RepoMessage as JSON over the websocket.
+func (c *WSConn) SendMessage(msg RepoMessage) error {
+	data, err := msg.Encode()
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.c.WriteMessage(websocket.TextMessage, data)
+}
+
+// RecvMessage reads a RepoMessage from the websocket.
+func (c *WSConn) RecvMessage() (RepoMessage, error) {
+	_, data, err := c.c.ReadMessage()
+	if err != nil {
+		return RepoMessage{}, err
+	}
+	return DecodeRepoMessage(data)
+}
+
 // Close closes the websocket.
 func (c *WSConn) Close() error { return c.c.Close() }
 


### PR DESCRIPTION
## Summary
- extend `LPConn` and `WSConn` with `SendMessage`/`RecvMessage`
- test message exchange over both TCP and WebSocket connectors
- document progress on the production roadmap

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68810de90b9c83269a8d2b653e3099e7