### PR TITLE
Implement basic RepoHandle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ This repository contains a work-in-progress port of the Automerge Repo from Rust
 - [x] Port or rewrite example programs from `rust/examples` in Go.
 - [x] Integrate `RepoMessage` handling with connectors.
 - [ ] Implement `RepoHandle` style connection management and background sync.
+  - Basic connection handling implemented, but document sync logic still pending.
 
 ## Part 2: Roadmap to Production
 

--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -21,8 +21,16 @@ future development.
   transmitting `RepoMessage` values.
   - Added unit tests `TestLPConnSendRecvMessage` and `TestWSConnSendRecvMessage`
     verifying JSON message exchange.
+- Introduced `RepoHandle` with basic peer management in `repo/handle.go`.
+  - Supports adding connections that forward incoming messages on a channel.
+  - Provides `SendMessage` and `Broadcast` helpers.
+  - Added unit test `TestRepoHandleMessageForwarding` using an in-memory connection.
 
 ## Missing / Next Steps
-- Connection lifecycle management and background goroutines similar to the
-  Rust `RepoHandle` implementation.
+- Connection lifecycle management remains incomplete and should evolve toward
+  the Rust `RepoHandle` design.
 - Integration of connectors with the example CLI for real networking.
+- Document synchronization logic is still missing; incoming messages are
+  delivered but not applied to documents.
+- CLI examples should be updated to use `RepoHandle` and demonstrate message
+  exchange over the network.

--- a/repo/handle.go
+++ b/repo/handle.go
@@ -1,0 +1,116 @@
+package repo
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Conn abstracts a bidirectional channel capable of sending and receiving
+// RepoMessage values. LPConn and WSConn satisfy this interface.
+type Conn interface {
+	SendMessage(RepoMessage) error
+	RecvMessage() (RepoMessage, error)
+	Close() error
+}
+
+// RepoHandle manages a Repo along with its active peer connections. It
+// spawns goroutines for each connection that forward incoming messages
+// onto the Inbox channel.
+type RepoHandle struct {
+	Repo *Repo
+
+	mu    sync.Mutex
+	peers map[RepoID]Conn
+
+	// Inbox delivers messages received from peers. It is unbuffered so callers
+	// should read from it promptly.
+	Inbox chan RepoMessage
+}
+
+// NewRepoHandle wraps r with connection management and returns the handle.
+func NewRepoHandle(r *Repo) *RepoHandle {
+	return &RepoHandle{
+		Repo:  r,
+		peers: make(map[RepoID]Conn),
+		Inbox: make(chan RepoMessage),
+	}
+}
+
+// AddConn registers a connection to a remote peer and starts a goroutine to
+// forward its messages onto the handle's Inbox channel.
+func (h *RepoHandle) AddConn(remote RepoID, c Conn) {
+	h.mu.Lock()
+	if h.peers == nil {
+		h.peers = make(map[RepoID]Conn)
+	}
+	h.peers[remote] = c
+	h.mu.Unlock()
+
+	go h.readLoop(remote, c)
+}
+
+// readLoop continuously receives messages from c and publishes them to Inbox.
+func (h *RepoHandle) readLoop(remote RepoID, c Conn) {
+	for {
+		msg, err := c.RecvMessage()
+		if err != nil {
+			break
+		}
+		h.Inbox <- msg
+	}
+	h.RemoveConn(remote)
+}
+
+// RemoveConn closes and deletes the connection associated with the peer.
+func (h *RepoHandle) RemoveConn(remote RepoID) {
+	h.mu.Lock()
+	c, ok := h.peers[remote]
+	if ok {
+		delete(h.peers, remote)
+	}
+	h.mu.Unlock()
+
+	if ok {
+		c.Close()
+	}
+}
+
+// SendMessage transmits msg to the specified remote peer if present.
+func (h *RepoHandle) SendMessage(remote RepoID, msg RepoMessage) error {
+	h.mu.Lock()
+	c, ok := h.peers[remote]
+	h.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("peer %s not found", remote)
+	}
+	return c.SendMessage(msg)
+}
+
+// Broadcast sends msg to all connected peers. Errors are returned for the first
+// failure encountered.
+func (h *RepoHandle) Broadcast(msg RepoMessage) error {
+	h.mu.Lock()
+	conns := make([]Conn, 0, len(h.peers))
+	for _, c := range h.peers {
+		conns = append(conns, c)
+	}
+	h.mu.Unlock()
+	for _, c := range conns {
+		if err := c.SendMessage(msg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Close terminates all peer connections and closes the Inbox channel.
+func (h *RepoHandle) Close() {
+	h.mu.Lock()
+	conns := h.peers
+	h.peers = make(map[RepoID]Conn)
+	h.mu.Unlock()
+	for _, c := range conns {
+		c.Close()
+	}
+	close(h.Inbox)
+}

--- a/repo/handle_test.go
+++ b/repo/handle_test.go
@@ -1,0 +1,63 @@
+package repo
+
+import (
+	"io"
+	"testing"
+	"time"
+)
+
+// mockConn is a simple in-memory connection for tests.
+type mockConn struct {
+	sendCh chan RepoMessage
+	recvCh chan RepoMessage
+}
+
+func newMockConn() (*mockConn, *mockConn) {
+	c1 := &mockConn{sendCh: make(chan RepoMessage, 1), recvCh: make(chan RepoMessage, 1)}
+	c2 := &mockConn{sendCh: c1.recvCh, recvCh: c1.sendCh}
+	return c1, c2
+}
+
+func (c *mockConn) SendMessage(m RepoMessage) error {
+	c.sendCh <- m
+	return nil
+}
+
+func (c *mockConn) RecvMessage() (RepoMessage, error) {
+	msg, ok := <-c.recvCh
+	if !ok {
+		return RepoMessage{}, io.EOF
+	}
+	return msg, nil
+}
+
+func (c *mockConn) Close() error {
+	close(c.sendCh)
+	return nil
+}
+
+func TestRepoHandleMessageForwarding(t *testing.T) {
+	h1 := NewRepoHandle(New())
+	h2 := NewRepoHandle(New())
+
+	c1, c2 := newMockConn()
+	h1.AddConn(h2.Repo.ID, c1)
+	h2.AddConn(h1.Repo.ID, c2)
+
+	msg := RepoMessage{Type: "sync", FromRepoID: h1.Repo.ID, ToRepoID: h2.Repo.ID}
+	if err := h1.SendMessage(h2.Repo.ID, msg); err != nil {
+		t.Fatalf("SendMessage error: %v", err)
+	}
+
+	select {
+	case got := <-h2.Inbox:
+		if got.Type != msg.Type || got.FromRepoID != msg.FromRepoID || got.ToRepoID != msg.ToRepoID {
+			t.Fatalf("unexpected message: %#v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for message")
+	}
+
+	h1.Close()
+	h2.Close()
+}


### PR DESCRIPTION
## Summary
- add `RepoHandle` to manage peer connections
- add `Conn` interface and channel-based message forwarding
- create unit test for the handle
- update roadmap docs and guidelines

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68810f3b0f60832682f4e68cdcbec69a