### PR TITLE
Add basic document sync and CLI integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,8 @@ This repository contains a work-in-progress port of the Automerge Repo from Rust
 - [x] Prototype networking support based on the Rust implementation.
 - [x] Port or rewrite example programs from `rust/examples` in Go.
 - [x] Integrate `RepoMessage` handling with connectors.
-- [ ] Implement `RepoHandle` style connection management and background sync.
-  - Basic connection handling implemented, but document sync logic still pending.
+- [x] Implement `RepoHandle` style connection management and background sync.
+  - Basic document sync added via Automerge's sync protocol.
 
 ## Part 2: Roadmap to Production
 

--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -25,12 +25,16 @@ future development.
   - Supports adding connections that forward incoming messages on a channel.
   - Provides `SendMessage` and `Broadcast` helpers.
   - Added unit test `TestRepoHandleMessageForwarding` using an in-memory connection.
+- Added basic document synchronization via `RepoHandle.SyncDocument` and
+  `RepoHandle.SyncAll`.
+  - Documents use Automerge's sync protocol to exchange changes.
+  - Unit test `TestRepoHandleSync` verifies syncing between two handles.
+- Updated `cmd/tcp-example` to use `RepoHandle` and connectors.
+  - On connect or accept it performs the join/peer handshake and syncs all
+    documents.
+  - Messages received are printed to stdout.
 
 ## Missing / Next Steps
 - Connection lifecycle management remains incomplete and should evolve toward
   the Rust `RepoHandle` design.
-- Integration of connectors with the example CLI for real networking.
-- Document synchronization logic is still missing; incoming messages are
-  delivered but not applied to documents.
-- CLI examples should be updated to use `RepoHandle` and demonstrate message
-  exchange over the network.
+- Additional CLI features like editing documents over the network are still planned.

--- a/repo/handle_sync_test.go
+++ b/repo/handle_sync_test.go
@@ -1,0 +1,40 @@
+package repo
+
+import (
+	"testing"
+	"time"
+
+	automerge "github.com/automerge/automerge-go"
+)
+
+// newMockConn reused from handle_test.go
+
+func TestRepoHandleSync(t *testing.T) {
+	h1 := NewRepoHandle(New())
+	h2 := NewRepoHandle(New())
+
+	c1, c2 := newMockConn()
+	h1.AddConn(h2.Repo.ID, c1)
+	h2.AddConn(h1.Repo.ID, c2)
+
+	doc1 := h1.Repo.NewDoc()
+	if err := doc1.Set("k", "v"); err != nil {
+		t.Fatalf("set err: %v", err)
+	}
+	doc2 := &Document{ID: doc1.ID, doc: automerge.New()}
+	h2.Repo.docs[doc1.ID] = doc2
+
+	if err := h1.SyncDocument(h2.Repo.ID, doc1.ID); err != nil {
+		t.Fatalf("sync error: %v", err)
+	}
+
+	// give the goroutines a moment to process
+	time.Sleep(10 * time.Millisecond)
+
+	if v, ok := doc2.Get("k"); !ok || v != "v" {
+		t.Fatalf("doc not synced: %v %v", v, ok)
+	}
+
+	h1.Close()
+	h2.Close()
+}

--- a/repo/handle_test.go
+++ b/repo/handle_test.go
@@ -44,7 +44,7 @@ func TestRepoHandleMessageForwarding(t *testing.T) {
 	h1.AddConn(h2.Repo.ID, c1)
 	h2.AddConn(h1.Repo.ID, c2)
 
-	msg := RepoMessage{Type: "sync", FromRepoID: h1.Repo.ID, ToRepoID: h2.Repo.ID}
+	msg := RepoMessage{Type: "ephemeral", FromRepoID: h1.Repo.ID, ToRepoID: h2.Repo.ID}
 	if err := h1.SendMessage(h2.Repo.ID, msg); err != nil {
 		t.Fatalf("SendMessage error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- implement Automerge sync state helper methods on Document
- expand RepoHandle with sync support and peer state tracking
- add SyncDocument/SyncAll APIs and handle sync messages
- integrate RepoHandle into tcp-example CLI to sync documents
- update tests and roadmap docs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688110a851108326bcbdf38b1120f775