### PR TITLE
Implement connection events in RepoHandle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ This repository contains a work-in-progress port of the Automerge Repo from Rust
 - [x] Integrate `RepoMessage` handling with connectors.
 - [x] Implement `RepoHandle` style connection management and background sync.
   - Basic document sync added via Automerge's sync protocol.
+- [x] Add connection lifecycle events via `RepoHandle.Events` channel.
 
 ## Part 2: Roadmap to Production
 

--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -29,12 +29,14 @@ future development.
   `RepoHandle.SyncAll`.
   - Documents use Automerge's sync protocol to exchange changes.
   - Unit test `TestRepoHandleSync` verifies syncing between two handles.
+- Added connection lifecycle events via `RepoHandle.Events`.
+  - Supports `peer_connected` and `peer_disconnected` notifications.
+  - Unit test `TestRepoHandleConnectionEvents` verifies event delivery.
 - Updated `cmd/tcp-example` to use `RepoHandle` and connectors.
   - On connect or accept it performs the join/peer handshake and syncs all
     documents.
   - Messages received are printed to stdout.
 
 ## Missing / Next Steps
-- Connection lifecycle management remains incomplete and should evolve toward
-  the Rust `RepoHandle` design.
 - Additional CLI features like editing documents over the network are still planned.
+- Document handles and reconnection logic remain to be implemented.

--- a/repo/handle_events_test.go
+++ b/repo/handle_events_test.go
@@ -1,0 +1,26 @@
+package repo
+
+import "testing"
+
+func TestRepoHandleConnectionEvents(t *testing.T) {
+	h1 := NewRepoHandle(New())
+	h2 := NewRepoHandle(New())
+
+	c1, _ := newMockConn()
+
+	go func() {
+		h1.AddConn(h2.Repo.ID, c1)
+	}()
+
+	if evt := <-h1.Events; evt.Type != EventPeerConnected || evt.Peer != h2.Repo.ID {
+		t.Fatalf("expected peer connected event, got %#v", evt)
+	}
+
+	h1.RemoveConn(h2.Repo.ID)
+	if evt := <-h1.Events; evt.Type != EventPeerDisconnected || evt.Peer != h2.Repo.ID {
+		t.Fatalf("expected peer disconnected event, got %#v", evt)
+	}
+
+	h1.Close()
+	h2.Close()
+}


### PR DESCRIPTION
## Summary
- add `HandleEvent` and lifecycle event channel to `RepoHandle`
- emit peer_connected and peer_disconnected events
- test connection event delivery
- document progress

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688113ca066c83268456fc3f01532335