### PR TITLE
Implement CBOR handshake and connection error events

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ been moved to the `rust/` directory for reference.
 The goal of this port is to provide a Go implementation that offers
 the same high level API for working with Automerge documents and
 network peers. Development is at an early stage and the API should be
-considered unstable. A prototype networking handshake is now
-available via `repo.Handshake`.
+considered unstable. A prototype networking handshake using CBOR
+encoding is now available via `repo.Handshake`.
 
 Basic document persistence is available using `repo.FsStore` and documents
 internally use the [automerge-go](https://github.com/automerge/automerge-go)
@@ -44,6 +44,9 @@ go run ./cmd/tcp-example -connect localhost:9999
 ```
 
 Each side prints the remote repository ID once the handshake completes.
+
+Messages and handshake data are encoded using CBOR for compatibility with
+other Automerge Repo implementations.
 
 WebSocket connections are supported via `repo.DialWebSocket` and
 `repo.AcceptWebSocket`. They use the same join/peer handshake over a WebSocket

--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -33,6 +33,11 @@ future development.
 - Added connection lifecycle events via `RepoHandle.Events`.
   - Supports `peer_connected` and `peer_disconnected` notifications.
   - Unit test `TestRepoHandleConnectionEvents` verifies event delivery.
+- Switched handshake messages to CBOR encoding across network helpers.
+  - `LPConn`, `WSConn` and the `Handshake` function now use CBOR.
+  - Added unit test `TestRepoHandleConnErrorEvent` exercising connection error events.
+- Introduced connection error events.
+  - `RepoHandle` publishes `conn_error` when a connection closes unexpectedly.
 - Updated `cmd/tcp-example` to use `RepoHandle` and connectors.
   - On connect or accept it performs the join/peer handshake and syncs all
     documents.
@@ -41,5 +46,4 @@ future development.
 ## Missing / Next Steps
 - Additional CLI features like editing documents over the network are still planned.
 - Document handles and reconnection logic remain to be implemented.
-- Handshake messages still use JSON; convert them to CBOR for full interoperability.
-- Review connection loops and add error propagation similar to the Rust `ConnComplete` API.
+- Review connection loops and continue improving error propagation similar to the Rust `ConnComplete` API.

--- a/repo/handle_events_test.go
+++ b/repo/handle_events_test.go
@@ -24,3 +24,31 @@ func TestRepoHandleConnectionEvents(t *testing.T) {
 	h1.Close()
 	h2.Close()
 }
+
+func TestRepoHandleConnErrorEvent(t *testing.T) {
+	h1 := NewRepoHandle(New())
+	h2 := NewRepoHandle(New())
+
+	c1, c2 := newMockConn()
+
+	h1.AddConn(h2.Repo.ID, c1)
+	if evt := <-h1.Events; evt.Type != EventPeerConnected || evt.Peer != h2.Repo.ID {
+		t.Fatalf("expected peer connected event, got %#v", evt)
+	}
+
+	// simulate remote closing connection
+	c2.Close()
+
+	evt := <-h1.Events
+	if evt.Type != EventConnError || evt.Peer != h2.Repo.ID || evt.Err == nil {
+		t.Fatalf("expected conn error event, got %#v", evt)
+	}
+
+	evt = <-h1.Events
+	if evt.Type != EventPeerDisconnected || evt.Peer != h2.Repo.ID {
+		t.Fatalf("expected peer disconnected event, got %#v", evt)
+	}
+
+	h1.Close()
+	h2.Close()
+}


### PR DESCRIPTION
## Summary
- encode handshake messages using CBOR instead of JSON
- add connection error events to `RepoHandle`
- update README with CBOR handshake info
- log progress in `ROADMAP_PROGRESS.md`
- add tests for connection error events

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6881308ab1c88326b98476825d17431a