### PR TITLE
Add release helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ API, improving reliability and providing tooling for real world use:
    programs to demonstrate document sharing across multiple peers. **(done)**
 4. [x] **Continuous integration** – configure a CI workflow that builds and runs
    tests on Linux, macOS and Windows. Include `go vet` and coverage reporting.
-5. **Versioned releases** – once the API stabilises, tag releases and provide
+5. [x] **Versioned releases** – once the API stabilises, tag releases and provide
    instructions for importing via Go modules.
 
 ## Maintaining this file

--- a/README.md
+++ b/README.md
@@ -78,3 +78,16 @@ All pushes and pull requests are validated by a GitHub Actions workflow defined
 in `.github/workflows/go.yml`. The workflow runs `go vet` and `go test` on
 Linux, macOS and Windows using the latest Go releases.
 
+
+## Release process
+
+Releases are tagged using semantic versions. The `scripts/release.sh` helper
+builds binaries for the example programs across supported platforms and
+packages them into a tarball. To cut a new version run:
+
+```bash
+./scripts/release.sh v0.1.0
+```
+
+The script creates and pushes the git tag then writes the build artifacts to
+`dist/`. Upload the resulting tarball when creating a GitHub release.

--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -50,9 +50,11 @@ future development.
   - Runs `go vet` and `go test` on Linux, macOS and Windows.
 - Added package level documentation in `repo/doc.go` describing the main types
   and how to use network connectors.
+- Added `scripts/release.sh` and release instructions in `README.md`.
+  - Provides a helper for tagging versions and building cross platform binaries.
 
 ## Missing / Next Steps
 - Document handles and reconnection logic remain to be implemented.
 - Review connection loops and continue improving error propagation similar to the Rust `ConnComplete` API.
 - More comprehensive usage examples would be helpful.
-- Versioned releases have not yet been prepared.
+- Consider automating GitHub releases in the future.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "usage: $0 <version>" >&2
+  exit 1
+fi
+
+VERSION=$1
+
+echo "Tagging release $VERSION"
+
+git tag -a "$VERSION" -m "Release $VERSION"
+
+git push origin "$VERSION"
+
+mkdir -p dist
+for dir in cmd/*; do
+  name=$(basename "$dir")
+  echo "Building $name for linux-amd64"
+  GOOS=linux GOARCH=amd64 go build -o dist/${name}-linux-amd64 "$dir"
+  echo "Building $name for darwin-amd64"
+  GOOS=darwin GOARCH=amd64 go build -o dist/${name}-darwin-amd64 "$dir"
+  echo "Building $name for windows-amd64"
+  GOOS=windows GOARCH=amd64 go build -o dist/${name}-windows-amd64.exe "$dir"
+  echo "" >/dev/null
+done
+
+TARBALL="automerge-repo-go-${VERSION}.tar.gz"
+tar -czf "$TARBALL" -C dist .
+
+echo "Release artifacts written to $TARBALL"


### PR DESCRIPTION
## Summary
- mark versioned releases checklist item as complete
- document release process in README
- log release helper progress in ROADMAP_PROGRESS
- add `scripts/release.sh` for tagging and building releases

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68814dc44e9c8326a458ab3c4945af84