### PR TITLE
Add connection completion signal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ work needed in this phase:
     out.
   - Update callers and unit tests to pass a context with timeout.
 - [ ] **Implement connection completion/retry logic**
-  - Introduce a `ConnComplete`-style mechanism in `repo/handle.go` to signal
+  - [x] Introduce a `ConnComplete`-style mechanism in `repo/handle.go` to signal
     when connection goroutines end.
   - Allow optional reconnection attempts via callbacks or a retry policy.
   - Extend tests in `repo/handle_events_test.go` to verify reconnection or

--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -55,9 +55,12 @@ future development.
 - Handshake helpers now accept a `context.Context` to allow timeouts.
   - `Connect`, `DialWebSocket` and `Handshake` updated along with all callers
     and unit tests.
+- Added `ConnComplete` to signal when peer goroutines exit.
+  - `RepoHandle.AddConn` now returns a completion handle.
+  - Added unit test `TestRepoHandleConnComplete` verifying the signal.
 
 ## Missing / Next Steps
-- Document handles and reconnection logic remain to be implemented.
+- Reconnection logic remains to be implemented.
 - Review connection loops and continue improving error propagation similar to the Rust `ConnComplete` API.
 - More comprehensive usage examples would be helpful.
 - Consider automating GitHub releases in the future.

--- a/cmd/tcp-example/main.go
+++ b/cmd/tcp-example/main.go
@@ -62,7 +62,7 @@ func main() {
 						c.Close()
 						return
 					}
-					handle.AddConn(remote, lp)
+					_ = handle.AddConn(remote, lp)
 					mu.Lock()
 					peers = append(peers, remote)
 					mu.Unlock()
@@ -85,7 +85,7 @@ func main() {
 			fmt.Println("handshake error:", err)
 			return
 		}
-		handle.AddConn(remote, lp)
+		_ = handle.AddConn(remote, lp)
 		mu.Lock()
 		peers = append(peers, remote)
 		mu.Unlock()

--- a/repo/handle_sync_test.go
+++ b/repo/handle_sync_test.go
@@ -14,8 +14,8 @@ func TestRepoHandleSync(t *testing.T) {
 	h2 := NewRepoHandle(New())
 
 	c1, c2 := newMockConn()
-	h1.AddConn(h2.Repo.ID, c1)
-	h2.AddConn(h1.Repo.ID, c2)
+	_ = h1.AddConn(h2.Repo.ID, c1)
+	_ = h2.AddConn(h1.Repo.ID, c2)
 
 	doc1 := h1.Repo.NewDoc()
 	if err := doc1.Set("k", "v"); err != nil {


### PR DESCRIPTION
## Summary
- implement `ConnComplete` for `RepoHandle`
- update examples and tests for new API
- verify `ConnComplete` with new unit test
- document progress in ROADMAP_PROGRESS.md
- mark partial completion of connection retry work in AGENTS.md

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6881f2c191d483268a51f39e56503dbd