### PR TITLE
Add multi-peer integration test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ work needed in this phase:
   - [x] Allow optional reconnection attempts via callbacks or a retry policy.
   - [x] Extend tests in `repo/handle_events_test.go` to verify reconnection or
     completion events.
-- [ ] **Add multi-peer integration tests**
+- [x] **Add multi-peer integration tests**
   - Create tests under `repo/` that run multiple `RepoHandle` instances
     connected via TCP or WebSockets.
   - Verify document changes propagate across all peers and lifecycle events are

--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -60,6 +60,7 @@ future development.
   - Added unit test `TestRepoHandleConnComplete` verifying the signal.
 - Implemented automatic reconnection via `RepoHandle.AddConnWithRetry`.
   - New test `TestRepoHandleReconnect` covers connection retry behaviour.
+- Added multi-peer integration test `TestMultiPeerSync` verifying document propagation across three interconnected handles.
 
 ## Missing / Next Steps
 - Review connection loops and continue improving error propagation similar to the Rust `ConnComplete` API.

--- a/repo/integration_test.go
+++ b/repo/integration_test.go
@@ -1,0 +1,88 @@
+package repo
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+func connectHandles(t *testing.T, ctx context.Context, a, b *RepoHandle) (ConnComplete, ConnComplete) {
+	c1, c2 := net.Pipe()
+	var wg sync.WaitGroup
+	var ca *LPConn
+	var cb *LPConn
+	var ra RepoID
+	var rb RepoID
+	var errA, errB error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		ca, rb, errA = Connect(ctx, c1, a.Repo.ID, Outgoing)
+	}()
+	go func() {
+		defer wg.Done()
+		cb, ra, errB = Connect(ctx, c2, b.Repo.ID, Incoming)
+	}()
+	wg.Wait()
+	if errA != nil || errB != nil {
+		t.Fatalf("connect error: %v %v", errA, errB)
+	}
+	cca := a.AddConn(rb, ca)
+	ccb := b.AddConn(ra, cb)
+	if evt := <-a.Events; evt.Type != EventPeerConnected || evt.Peer != rb {
+		t.Fatalf("expected peer connected event, got %#v", evt)
+	}
+	if evt := <-b.Events; evt.Type != EventPeerConnected || evt.Peer != ra {
+		t.Fatalf("expected peer connected event, got %#v", evt)
+	}
+	return cca, ccb
+}
+
+func TestMultiPeerSync(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	h1 := NewRepoHandle(New())
+	h2 := NewRepoHandle(New())
+	h3 := NewRepoHandle(New())
+
+	cc12a, cc12b := connectHandles(t, ctx, h1, h2)
+	cc23a, cc23b := connectHandles(t, ctx, h2, h3)
+	cc31a, cc31b := connectHandles(t, ctx, h3, h1)
+
+	doc := h1.Repo.NewDoc()
+	if err := doc.Set("k", "v"); err != nil {
+		t.Fatalf("set err: %v", err)
+	}
+	if err := h1.SyncAll(h2.Repo.ID); err != nil {
+		t.Fatalf("sync err: %v", err)
+	}
+	if err := h1.SyncAll(h3.Repo.ID); err != nil {
+		t.Fatalf("sync err: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	if d, ok := h2.Repo.GetDoc(doc.ID); !ok {
+		t.Fatalf("h2 missing doc")
+	} else if v, ok := d.Get("k"); !ok || v != "v" {
+		t.Fatalf("h2 doc mismatch: %v %v", v, ok)
+	}
+	if d, ok := h3.Repo.GetDoc(doc.ID); !ok {
+		t.Fatalf("h3 missing doc")
+	} else if v, ok := d.Get("k"); !ok || v != "v" {
+		t.Fatalf("h3 doc mismatch: %v %v", v, ok)
+	}
+
+	h1.Close()
+	h2.Close()
+	h3.Close()
+	_ = cc12a.Await()
+	_ = cc12b.Await()
+	_ = cc23a.Await()
+	_ = cc23b.Await()
+	_ = cc31a.Await()
+	_ = cc31b.Await()
+}


### PR DESCRIPTION
## Summary
- mark multi-peer integration tests as done
- document new multi-peer test in roadmap progress
- add `TestMultiPeerSync` to verify sync across three handles

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688202bf82e48326a080c71bd342a323