### PR TITLE
Refine connection completion handling

### DIFF
--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -58,6 +58,10 @@ future development.
 - Added `ConnComplete` to signal when peer goroutines exit.
   - `RepoHandle.AddConn` now returns a completion handle.
   - Added unit test `TestRepoHandleConnComplete` verifying the signal.
+- ConnComplete now provides structured reasons via `ConnFinished`.
+  - `RepoHandle` connection loops emit `ConnFinishedRecvError`, `ConnFinishedSendError`
+    or `ConnFinishedLocalClose`.
+  - Updated tests to assert on the returned error field.
 - Implemented automatic reconnection via `RepoHandle.AddConnWithRetry`.
   - New test `TestRepoHandleReconnect` covers connection retry behaviour.
 - Added multi-peer integration test `TestMultiPeerSync` verifying document propagation across three interconnected handles.
@@ -70,7 +74,6 @@ future development.
   - Added unit test `TestDocumentHandleAutoSave` verifying saved data.
 
 ## Missing / Next Steps
-- Review connection loops and continue improving error propagation similar to the Rust `ConnComplete` API.
 - More comprehensive usage examples would be helpful.
 - Consider automating GitHub releases in the future.
 - Expand `DocumentHandle` integration with `RepoHandle` and add more

--- a/repo/handle_events_test.go
+++ b/repo/handle_events_test.go
@@ -76,7 +76,7 @@ func TestRepoHandleConnComplete(t *testing.T) {
 	c2.Close()
 
 	// wait for completion
-	if err := cc.Await(); err == nil {
+	if fin := cc.Await(); fin.Err == nil {
 		t.Fatalf("expected error, got nil")
 	}
 


### PR DESCRIPTION
## Summary
- add `ConnFinished` with reasons for connection termination
- signal connection completion reasons from RepoHandle
- update reconnect logic to use new completion values
- adjust tests for new struct
- note progress in roadmap

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68820b902b188326a7aac2c66b1f40ea